### PR TITLE
Use find() rather than filter()[0]

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -3,31 +3,31 @@ const iso = require('./iso-3166.js');
 exports.whereCountry = function (name) {
   name = name.toUpperCase();
 
-  return iso.filter(function (country) {
+  return iso.find(function (country) {
     return country.country.toUpperCase() === name;
-  })[0];
+  });
 }
 
 exports.whereAlpha2 = function (alpha2) {
   alpha2 = alpha2.toUpperCase();
 
-  return iso.filter(function (country) {
+  return iso.find(function (country) {
     return country.alpha2 === alpha2;
-  })[0];
+  });
 }
 
 exports.whereAlpha3 = function (alpha3) {
   alpha3 = alpha3.toUpperCase();
 
-  return iso.filter(function (country) {
+  return iso.find(function (country) {
     return country.alpha3 === alpha3;
-  })[0];
+  });
 }
 
 exports.whereNumeric = function (numeric) {
   numeric = numeric.toString();
 
-  return iso.filter(function (country) {
+  return iso.find(function (country) {
     return country.numeric === numeric;
-  })[0];
+  });
 }


### PR DESCRIPTION
The advantage of `find()` is that it stops when a result is found and does not build a list of the results. Both [filter](http://node.green/#ES2015-built-ins-typed-arrays--TypedArray--prototype-filter) and [find](http://node.green/#ES2015-built-ins-typed-arrays--TypedArray--prototype-find) are available for 4.8.3 and above so compatibility will not change.