### PR TITLE
fix: use official name for U.S. Virgin Islands to distinguish with British Virgin Islands

### DIFF
--- a/src/iso-3166.ts
+++ b/src/iso-3166.ts
@@ -1465,7 +1465,7 @@ const countries: Country[] = [
     numeric: '092',
   },
   {
-    country: 'Virgin Islands',
+    country: 'Virgin Islands of the United States',
     alpha2: 'VI',
     alpha3: 'VIR',
     numeric: '850',


### PR DESCRIPTION
The official name of the British territory is the Virgin Islands, and the official name of the U.S. territory is the Virgin Islands of the United States (taken from [wiki](https://en.wikipedia.org/wiki/Virgin_Islands)).

<details><summary>Click to show selector issue</summary>
<img width="473" alt="selector" src="https://user-images.githubusercontent.com/4462680/136486054-3d63b50b-957c-4b5b-afff-51195c942eb8.png">
</details>