### PR TITLE
Update countries

### DIFF
--- a/src/iso-3166.ts
+++ b/src/iso-3166.ts
@@ -1369,7 +1369,7 @@ const countries: Country[] = [
     numeric: '788',
   },
   {
-    country: 'Turkey',
+    country: 'Türkiye',
     alpha2: 'TR',
     alpha3: 'TUR',
     numeric: '792',

--- a/src/iso-3166.ts
+++ b/src/iso-3166.ts
@@ -1285,7 +1285,7 @@ const countries: Country[] = [
     numeric: '744',
   },
   {
-    country: 'Swaziland',
+    country: 'Eswatini',
     alpha2: 'SZ',
     alpha3: 'SWZ',
     numeric: '748',

--- a/src/iso-3166.ts
+++ b/src/iso-3166.ts
@@ -793,7 +793,7 @@ const countries: Country[] = [
     numeric: '446',
   },
   {
-    country: 'Macedonia',
+    country: 'North Macedonia',
     alpha2: 'MK',
     alpha3: 'MKD',
     numeric: '807',


### PR DESCRIPTION
Update a few countries who have officially changed their name in the last few years:

- Macedonia → North Macedonia
- Swaziland → Eswatini
- Turkey → Türkiye

These are the official short names (ie, not "Republic of ...").